### PR TITLE
TASK-185712 fix potential memory overruns

### DIFF
--- a/modules/curl.c
+++ b/modules/curl.c
@@ -326,7 +326,7 @@ static size_t readerCallback(void *ptr, size_t size, size_t nmemb, void *stream)
 		len = lua_strlen(c->L, -1);
 		max = size * nmemb;
 		if (len > max) {
-			luaL_error(c->L, "thrlua:readerCallback buffer overflow. Truncated len %zu max %zu\n", len, max);
+			fprintf(stderr, "thrlua:readerCallback buffer overflow. Truncated len %zu max %zu\n", len, max);
 			len = max;
 		}
 		memcpy(ptr, readBytes, len);

--- a/modules/pcre.c
+++ b/modules/pcre.c
@@ -314,7 +314,7 @@ static int perform_regex(lua_State *thr, int mode)
                     if (bref >= sizeof(name) - 1 && walk < repend) {
                       if (walk[0] != '}') {
                         /* name was truncated, skip remaining and warn */
-                        luaL_error(thr, "thrlua:perform_regex buffer overflow. Truncated max %zu\n", sizeof(name));
+                        fprintf(stderr, "thrlua:perform_regex buffer overflow. Truncated max %zu\n", sizeof(name));
                         while (walk < repend && walk[0] != '}') {
                           walk++;
                         }


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Touches low-level C string/buffer handling in libcurl and PCRE paths; while the change is small and defensive, it can subtly affect I/O behavior via truncation and error logging.
> 
> **Overview**
> Prevents potential memory overruns in two C modules by adding explicit length bounds checks.
> 
> In `modules/curl.c`, `readerCallback` now caps the number of bytes copied from the Lua-provided string to libcurl’s buffer and logs when truncation occurs.
> 
> In `modules/pcre.c`, parsing of `${name}` replacement backreferences now bounds writes into the fixed-size `name` buffer, skips any remaining characters until `}` when truncated, and logs a warning.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 4d1a5a1d1c61567ca9e4c2cc1ddee7c77fbbc5c2. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->