### PR TITLE
TASK-185818 fix race condition during new object createion

### DIFF
--- a/modules/curl.c
+++ b/modules/curl.c
@@ -326,7 +326,7 @@ static size_t readerCallback(void *ptr, size_t size, size_t nmemb, void *stream)
 		len = lua_strlen(c->L, -1);
 		max = size * nmemb;
 		if (len > max) {
-			fprintf(stderr, "thrlua:readerCallback buffer overflow. Truncated len %zu max %zu\n", len, max);
+			thrlua_log(c->L, DCRITICAL, "thrlua:readerCallback buffer overflow. Truncated len %zu max %zu\n", len, max);
 			len = max;
 		}
 		memcpy(ptr, readBytes, len);

--- a/modules/pcre.c
+++ b/modules/pcre.c
@@ -314,7 +314,7 @@ static int perform_regex(lua_State *thr, int mode)
                     if (bref >= sizeof(name) - 1 && walk < repend) {
                       if (walk[0] != '}') {
                         /* name was truncated, skip remaining and warn */
-                        fprintf(stderr, "thrlua:perform_regex buffer overflow. Truncated max %zu\n", sizeof(name));
+                        thrlua_log(thr, DCRITICAL, "thrlua:perform_regex buffer overflow. Truncated max %zu\n", sizeof(name));
                         while (walk < repend && walk[0] != '}') {
                           walk++;
                         }

--- a/src/lgc.c
+++ b/src/lgc.c
@@ -1481,11 +1481,12 @@ static GCheader *new_obj(lua_State *L, enum lua_obj_type tt,
   o->tt = tt;
   o->marked = !L->black;
   o->xref = ck_pr_load_32(&G(L)->notxref);
-  make_grey(L, o);
-  /* The collector can be walking our heap, which isn't safe.  So block it
-   * while we're adding to it */
+  /* Block the collector while modifying the heap.
+   * Insert into heap BEFORE make_grey to ensure the object is fully linked
+   * before it becomes visible to the GC via the grey stack. */
   block_collector(L, pt);
   TAILQ_INSERT_HEAD(&L->heap->objects, o, allocd);
+  make_grey(L, o);
   unblock_collector(L, pt);
 
   return o;


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Touches core GC object-allocation ordering and locking, so mistakes could cause hard-to-debug memory corruption or deadlocks; logging-only changes in modules are low risk.
> 
> **Overview**
> Fixes a potential GC race in `src/lgc.c` during `new_obj` allocation by **blocking the collector while linking the new object into the heap** and only then calling `make_grey`, preventing the GC from seeing a grey-stack entry for an object not yet fully linked.
> 
> Standardizes buffer-overflow warnings in `modules/curl.c` and `modules/pcre.c` by replacing direct `fprintf(stderr, ...)` calls with `thrlua_log(..., DCRITICAL, ...)` so these events go through the shared logging mechanism.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 06d6c1edda0700ba3403f9bd87acf3d8864464c6. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->