### PR TITLE
TASK-187380 add fencing arount table.initialized access

### DIFF
--- a/modules/curl.c
+++ b/modules/curl.c
@@ -26,6 +26,7 @@
 #endif
 
 #include <lauxlib.h>
+#include "thrlua.h"
 
 #if !defined(LUA_VERSION_NUM) || (LUA_VERSION_NUM <= 500)
 #define luaL_checkstring luaL_check_string

--- a/src/ltable.c
+++ b/src/ltable.c
@@ -385,6 +385,8 @@ Table *luaH_new (lua_State *L, int narray, int nhash) {
   t->node = cast(Node *, dummynode);
   setarrayvector(L, t, narray);
   setnodevector(L, t, nhash);
+  /* Release fence: ensure all table data is visible before initialized flag */
+  ck_pr_fence_store();
   ck_pr_store_uint(&t->initialized, 1);
   return t;
 }


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Touches concurrency-sensitive GC/table initialization paths; incorrect fencing or assumptions could cause hard-to-debug races or crashes, though the changes are small and targeted.
> 
> **Overview**
> Adds **memory-ordering fences** around `Table->initialized` to make table publication safe across threads: `luaH_new` now does a store/release fence before setting `initialized`, and GC table traversal in `lgc.c` does a load/acquire fence after observing `initialized`.
> 
> Hardens thread creation in `luaC_newobj` by handling `new_heap` allocation failure (freeing the partially allocated `lua_State` and raising `luaM_toobig`). Also adds an explicit `thrlua.h` include to `modules/curl.c`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 90b7c11aaa840d71c6db7cba468f44e7daf0e158. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->