### PR TITLE
TASK-189179 move ref count decrement into lock

### DIFF
--- a/src/lapi.c
+++ b/src/lapi.c
@@ -153,11 +153,14 @@ LUA_API void *(lua_get_extra)(lua_State *L)
 LUA_API void lua_delrefthread(lua_State *L, lua_State *inheritor)
 {
   bool last;
+
+  /* Lock L BEFORE decrementing ref count to prevent a race with GC */
+  lua_lock(L);
   ck_pr_dec_32_zero(&L->gch.ref, &last);
   if (!last) {
+    lua_unlock(L);
     return;
   }
-  lua_lock(L);
   lua_settop(L, 0);
   /* We already done this before calling lua_delrefthread */
   /* luaC_localgc(L, GCDESTROY); */


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Touches low-level Lua threading/GC teardown ordering; small change but concurrency-sensitive and could affect thread lifetime/locking behavior under load.
> 
> **Overview**
> Fixes a potential GC race in `lua_delrefthread` by acquiring `lua_lock(L)` *before* decrementing the thread refcount, and releasing the lock early on the non-final-ref fast path.
> 
> This reorders thread teardown/inheritance so the “last ref” transition happens under the state lock, reducing the chance of concurrent GC observing an inconsistent refcount.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 0222709070a9d0b58b2e799c37cbdad37ab666e5. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->