### PR TITLE
Task 194243

### DIFF
--- a/src/lapi.c
+++ b/src/lapi.c
@@ -1233,8 +1233,13 @@ LUA_API int lua_error (lua_State *L) {
   lua_lock(L);
   LUAI_TRY_BLOCK(L) {
     api_checknelems(L, 1);
-    if (!L->errorJmp) {
-      /* Use raw accessors (ttisstring/svalue) instead of the public API
+    if (!lj.previous) {
+      /* Log only when there is no outer error handler -- i.e. the error
+       * will ultimately reach the panic branch.  We check lj.previous
+       * (not L->errorJmp) because LUAI_TRY_BLOCK already set
+       * L->errorJmp = &lj, so L->errorJmp is always non-NULL here.
+       *
+       * Use raw accessors (ttisstring/svalue) instead of the public API
        * (lua_isstring/lua_tostring).  lua_isstring returns true for
        * numbers, and lua_tostring -> lua_tolstring calls lua_lock for
        * number-to-string conversion, which would deadlock since we

--- a/src/lapi.c
+++ b/src/lapi.c
@@ -1232,12 +1232,10 @@ LUA_API int lua_gc (lua_State *L, int what, int data) {
 LUA_API int lua_error (lua_State *L) {
   lua_lock(L);
   LUAI_TRY_BLOCK(L) {
-    {
       const char *msg = lua_isstring(L, -1) ? lua_tostring(L, -1) : "(non-string error)";
       thrlua_log(L, DCRITICAL, "lua_error called 1: %s\n", msg);
-    }
     api_checknelems(L, 1);
-      thrlua_log(L, DCRITICAL, "lua_error called 2\n", );
+      thrlua_log(L, DCRITICAL, "lua_error called %s\n", "end");
     luaG_errormsg(L);
   } LUAI_TRY_FINALLY(L) {
     lua_unlock(L);

--- a/src/lapi.c
+++ b/src/lapi.c
@@ -1232,10 +1232,12 @@ LUA_API int lua_gc (lua_State *L, int what, int data) {
 LUA_API int lua_error (lua_State *L) {
   lua_lock(L);
   LUAI_TRY_BLOCK(L) {
-      const char *msg = lua_isstring(L, -1) ? lua_tostring(L, -1) : "(non-string error)";
-      thrlua_log(L, DCRITICAL, "lua_error called 1: %s\n", msg);
     api_checknelems(L, 1);
-      thrlua_log(L, DCRITICAL, "lua_error called %s\n", "end");
+    {
+      const char *msg = lua_isstring(L, -1) ? lua_tostring(L, -1) : "(non-string error)";
+      thrlua_log(L, DCRITICAL, "lua_error (%s): %s\n",
+        L->errorJmp ? "caught" : "unhandled", msg);
+    }
     luaG_errormsg(L);
   } LUAI_TRY_FINALLY(L) {
     lua_unlock(L);

--- a/src/lapi.c
+++ b/src/lapi.c
@@ -1233,10 +1233,6 @@ LUA_API int lua_error (lua_State *L) {
   lua_lock(L);
   LUAI_TRY_BLOCK(L) {
     api_checknelems(L, 1);
-    {
-      const char *msg = lua_isstring(L, -1) ? lua_tostring(L, -1) : "(non-string error)";
-      thrlua_log(L, DCRITICAL, "lua_error called: %s\n", msg);
-    }
     luaG_errormsg(L);
   } LUAI_TRY_FINALLY(L) {
     lua_unlock(L);

--- a/src/lapi.c
+++ b/src/lapi.c
@@ -1233,10 +1233,15 @@ LUA_API int lua_error (lua_State *L) {
   lua_lock(L);
   LUAI_TRY_BLOCK(L) {
     api_checknelems(L, 1);
-    {
-      const char *msg = lua_isstring(L, -1) ? lua_tostring(L, -1) : "(non-string error)";
-      thrlua_log(L, DCRITICAL, "lua_error (%s): %s\n",
-        L->errorJmp ? "caught" : "unhandled", msg);
+    if (!L->errorJmp) {
+      /* Use raw accessors (ttisstring/svalue) instead of the public API
+       * (lua_isstring/lua_tostring).  lua_isstring returns true for
+       * numbers, and lua_tostring -> lua_tolstring calls lua_lock for
+       * number-to-string conversion, which would deadlock since we
+       * already hold the lock from lua_error's lua_lock above. */
+      StkId o = L->top - 1;
+      const char *msg = ttisstring(o) ? svalue(o) : "(non-string error)";
+      thrlua_log(L, DCRITICAL, "lua_error (unhandled): %s\n", msg);
     }
     luaG_errormsg(L);
   } LUAI_TRY_FINALLY(L) {

--- a/src/lapi.c
+++ b/src/lapi.c
@@ -1233,6 +1233,10 @@ LUA_API int lua_error (lua_State *L) {
   lua_lock(L);
   LUAI_TRY_BLOCK(L) {
     api_checknelems(L, 1);
+    {
+      const char *msg = lua_isstring(L, -1) ? lua_tostring(L, -1) : "(non-string error)";
+      thrlua_log(L, DCRITICAL, "lua_error called: %s\n", msg);
+    }
     luaG_errormsg(L);
   } LUAI_TRY_FINALLY(L) {
     lua_unlock(L);

--- a/src/lapi.c
+++ b/src/lapi.c
@@ -1233,10 +1233,11 @@ LUA_API int lua_error (lua_State *L) {
   lua_lock(L);
   LUAI_TRY_BLOCK(L) {
     {
-//      const char *msg = lua_isstring(L, -1) ? lua_tostring(L, -1) : "(non-string error)";
-//      thrlua_log(L, DCRITICAL, "lua_error called: %s\n", msg);
+      const char *msg = lua_isstring(L, -1) ? lua_tostring(L, -1) : "(non-string error)";
+      thrlua_log(L, DCRITICAL, "lua_error called 1: %s\n", msg);
     }
     api_checknelems(L, 1);
+      thrlua_log(L, DCRITICAL, "lua_error called 2\n", );
     luaG_errormsg(L);
   } LUAI_TRY_FINALLY(L) {
     lua_unlock(L);

--- a/src/lapi.c
+++ b/src/lapi.c
@@ -1232,6 +1232,10 @@ LUA_API int lua_gc (lua_State *L, int what, int data) {
 LUA_API int lua_error (lua_State *L) {
   lua_lock(L);
   LUAI_TRY_BLOCK(L) {
+    {
+//      const char *msg = lua_isstring(L, -1) ? lua_tostring(L, -1) : "(non-string error)";
+//      thrlua_log(L, DCRITICAL, "lua_error called: %s\n", msg);
+    }
     api_checknelems(L, 1);
     luaG_errormsg(L);
   } LUAI_TRY_FINALLY(L) {

--- a/src/ldebug.c
+++ b/src/ldebug.c
@@ -631,15 +631,11 @@ void luaG_errormsg (lua_State *L) {
     incr_top(L);
     luaD_call(L, L->top - 2, 1);  /* call it */
   }
-  /* Only log when there is no error handler -- that means the
-   * subsequent luaD_throw will hit the panic branch.  When
-   * L->errorJmp is set the error will be caught by pcall/xpcall
-   * and is part of normal control flow (e.g. lua-aws uses pcall
-   * for method-existence checks). */
-  if (!L->errorJmp) {
+  {
     const char *msg = (L->top > L->base && ttisstring(L->top - 1))
       ? svalue(L->top - 1) : "(non-string error)";
-    thrlua_log(L, DCRITICAL, "luaG_errormsg: %s\n", msg);
+    thrlua_log(L, DCRITICAL, "luaG_errormsg (%s): %s\n",
+      L->errorJmp ? "caught" : "unhandled", msg);
   }
   luaD_throw(L, LUA_ERRRUN);
 }

--- a/src/ldebug.c
+++ b/src/ldebug.c
@@ -631,6 +631,11 @@ void luaG_errormsg (lua_State *L) {
     incr_top(L);
     luaD_call(L, L->top - 2, 1);  /* call it */
   }
+  {
+    const char *msg = (L->top > L->base && ttisstring(L->top - 1))
+      ? svalue(L->top - 1) : "(non-string error)";
+    thrlua_log(L, DCRITICAL, "luaG_errormsg: %s\n", msg);
+  }
   luaD_throw(L, LUA_ERRRUN);
 }
 

--- a/src/ldebug.c
+++ b/src/ldebug.c
@@ -631,7 +631,12 @@ void luaG_errormsg (lua_State *L) {
     incr_top(L);
     luaD_call(L, L->top - 2, 1);  /* call it */
   }
-  {
+  /* Only log when there is no error handler -- that means the
+   * subsequent luaD_throw will hit the panic branch.  When
+   * L->errorJmp is set the error will be caught by pcall/xpcall
+   * and is part of normal control flow (e.g. lua-aws uses pcall
+   * for method-existence checks). */
+  if (!L->errorJmp) {
     const char *msg = (L->top > L->base && ttisstring(L->top - 1))
       ? svalue(L->top - 1) : "(non-string error)";
     thrlua_log(L, DCRITICAL, "luaG_errormsg: %s\n", msg);

--- a/src/ldebug.c
+++ b/src/ldebug.c
@@ -631,11 +631,10 @@ void luaG_errormsg (lua_State *L) {
     incr_top(L);
     luaD_call(L, L->top - 2, 1);  /* call it */
   }
-  {
+  if (!L->errorJmp) {
     const char *msg = (L->top > L->base && ttisstring(L->top - 1))
       ? svalue(L->top - 1) : "(non-string error)";
-    thrlua_log(L, DCRITICAL, "luaG_errormsg (%s): %s\n",
-      L->errorJmp ? "caught" : "unhandled", msg);
+    thrlua_log(L, DCRITICAL, "luaG_errormsg (unhandled): %s\n", msg);
   }
   luaD_throw(L, LUA_ERRRUN);
 }

--- a/src/ldo.c
+++ b/src/ldo.c
@@ -70,7 +70,7 @@ void luaD_throw (lua_State *L, int errcode) {
   }
   else {
     thrlua_log(L, DCRITICAL,
-      "luaD_throw: no error handler, errcode=%d, L=%p, invoking panic",
+      "luaD_throw: no error handler, errcode=%d, L=%p, invoking panic\n",
       errcode, (void *)L);
     L->status = cast_byte(errcode);
     if (G(L)->panic) {

--- a/src/ldo.c
+++ b/src/ldo.c
@@ -69,6 +69,9 @@ void luaD_throw (lua_State *L, int errcode) {
     LUAI_THROW(L, L->errorJmp);
   }
   else {
+    thrlua_log(L, DCRITICAL,
+      "luaD_throw: no error handler, errcode=%d, L=%p, invoking panic",
+      errcode, (void *)L);
     L->status = cast_byte(errcode);
     if (G(L)->panic) {
       resetstack(L, errcode);

--- a/src/lstrlib.c
+++ b/src/lstrlib.c
@@ -138,8 +138,16 @@ static int str_dump (lua_State *L) {
   luaL_checktype(L, 1, LUA_TFUNCTION);
   lua_settop(L, 1);
   luaL_buffinit(L,&b);
-  if (lua_dump(L, writer, &b) != 0)
-    luaL_error(L, "unable to dump given function");
+  if (lua_dump(L, writer, &b) != 0) {
+    lua_Debug ar;
+    lua_pushvalue(L, 1);
+    lua_getinfo(L, ">nS", &ar);
+    luaL_error(L, "unable to dump given function (%s '%s' defined at %s:%d)",
+      ar.what ? ar.what : "?",
+      ar.name ? ar.name : "(anonymous)",
+      ar.short_src ? ar.short_src : "?",
+      ar.linedefined);
+  }
   luaL_pushresult(&b);
   return 1;
 }

--- a/src/thrlua.h
+++ b/src/thrlua.h
@@ -260,16 +260,6 @@ extern void lua_do_longjmp(luai_jmpbuf env, int val)
       "re-throwing with %s outer handler, L=%p", \
       lj.status, lj.file, lj.line, \
       lj.previous ? "an" : "NO", (void *)(L)); \
-    /* Re-acquire the lock before re-throwing.  The LUAI_TRY_FINALLY \
-     * block has already called lua_unlock(), but luaD_throw() expects \
-     * the lock to be held: if there is an outer error handler its \
-     * FINALLY will lua_unlock(), and if there is no outer handler the \
-     * panic path in luaD_throw() calls lua_unlock() explicitly.  \
-     * Without this re-lock we double-unlock the pthread mutex which \
-     * is undefined behavior and corrupts the mutex on Linux/glibc, \
-     * causing every subsequent lua_lock() on this lua_State to fail \
-     * with EINVAL and abort(). */ \
-    lua_lock((L)); \
     luaD_throw((L), lj.status); \
   } \
 } while(0)

--- a/src/thrlua.h
+++ b/src/thrlua.h
@@ -254,6 +254,22 @@ extern void lua_do_longjmp(luai_jmpbuf env, int val)
 #define LUAI_TRY_END(L) \
   (L)->errorJmp = lj.previous; \
   if (lj.status) { \
+    /* Log the error and re-throw path for diagnostics. */ \
+    thrlua_log((L), DCRITICAL, \
+      "LUAI_TRY_END: error status=%d in TRY block at %s:%d, " \
+      "re-throwing with %s outer handler, L=%p", \
+      lj.status, lj.file, lj.line, \
+      lj.previous ? "an" : "NO", (void *)(L)); \
+    /* Re-acquire the lock before re-throwing.  The LUAI_TRY_FINALLY \
+     * block has already called lua_unlock(), but luaD_throw() expects \
+     * the lock to be held: if there is an outer error handler its \
+     * FINALLY will lua_unlock(), and if there is no outer handler the \
+     * panic path in luaD_throw() calls lua_unlock() explicitly.  \
+     * Without this re-lock we double-unlock the pthread mutex which \
+     * is undefined behavior and corrupts the mutex on Linux/glibc, \
+     * causing every subsequent lua_lock() on this lua_State to fail \
+     * with EINVAL and abort(). */ \
+    lua_lock((L)); \
     luaD_throw((L), lj.status); \
   } \
 } while(0)


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Touches core runtime error/locking code paths; mistakes could alter error propagation or reintroduce deadlocks/crashes, though changes are narrowly scoped and largely additive logging/guarding.
> 
> **Overview**
> **Hardens Lua error propagation/panic paths** by removing an unconditional `lua_unlock(L)` in `luaD_throw`’s no-handler (panic) branch that could double-unlock and corrupt the pthread mutex during re-throws.
> 
> Adds *low-frequency* critical logging for otherwise-unhandled errors: `lua_error`, `luaG_errormsg`, and `LUAI_TRY_END` now emit `DCRITICAL` logs only when there is no outer error handler, using raw stack accessors to avoid lock re-entry/deadlocks.
> 
> Improves `string.dump` failure diagnostics by including function identity/source location details via `lua_getinfo` in the raised error message.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit fbf904bf9d6cef840217b7ce301d9a7320cc90fb. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->