### PR TITLE
TASK-208476: limit the number of table entries dumped in a gimli trace

### DIFF
--- a/src/gimli.c
+++ b/src/gimli.c
@@ -118,8 +118,6 @@ static int show_table(gimli_proc_t proc, Table *tp, int limit)
     return 1;
   }
 
-  int total_entries = t.sizearray + twoto(t.lsizenode);
-
   printf("{ ");
   for (i = 0; i < t.sizearray; i++) {
     TValue val;
@@ -133,8 +131,8 @@ static int show_table(gimli_proc_t proc, Table *tp, int limit)
     }
 
     if (entries >= table_entry_limit) {
-      printf("%.*s... (%d more entries not shown)\n",
-          indent, indent_str, total_entries - entries);
+      printf("%.*s... (truncated after %d entries)\n",
+          indent, indent_str, entries);
       goto done;
     }
 
@@ -159,8 +157,8 @@ static int show_table(gimli_proc_t proc, Table *tp, int limit)
     }
 
     if (entries >= table_entry_limit) {
-      printf("%.*s... (%d more entries not shown)\n",
-          indent, indent_str, total_entries - entries);
+      printf("%.*s... (truncated after %d entries)\n",
+          indent, indent_str, entries);
       goto done;
     }
 


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> <sup>[Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) is generating a summary for commit 87df71eb296ac843d3a487d00f04cf976275ae46. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->