### PR TITLE
TASK-209191 block global trace while inheriting thread data

### DIFF
--- a/src/ldo.c
+++ b/src/ldo.c
@@ -440,6 +440,7 @@ int lua_suspend(lua_State *L, lua_ResumeFunc func, void *ptr)
       luaG_runerror(L, "attempt to suspend across metamethod/C-call boundary");
     L->base = L->top;  /* protect stack slots below */
     L->status = LUA_SUSPEND;
+    ck_pr_inc_32(&L->gch.ref);
   } LUAI_TRY_FINALLY(L) {
     lua_unlock(L);
   } LUAI_TRY_END(L);
@@ -525,8 +526,10 @@ static void lua_run_on_resume(lua_State *L, int *nargs, int *status) {
 LUA_API int lua_resume (lua_State *L, int nargs) {
   int status = 0;
   const char *reserr = NULL;
+  int was_suspended;
 
   lua_lock(L);
+  was_suspended = (L->status == LUA_SUSPEND);
   LUAI_TRY_BLOCK(L) {
     if (L->status != LUA_YIELD && L->status != LUA_SUSPEND
         && (L->status != 0 || L->ci != L->base_ci)) {
@@ -567,6 +570,9 @@ LUA_API int lua_resume (lua_State *L, int nargs) {
   } LUAI_TRY_FINALLY(L) {
     lua_unlock(L);
   } LUAI_TRY_END(L);
+  if (was_suspended) {
+    ck_pr_dec_32(&L->gch.ref);
+  }
   return status;
 }
 

--- a/src/lgc.c
+++ b/src/lgc.c
@@ -1632,11 +1632,12 @@ void luaC_inherit_thread(lua_State *L, lua_State *th)
   }
 
   pt = luaC_get_per_thread(L);
-  block_collector(L, pt);
 
   /* when a thread is reclaimed, the executing thread
    * needs to steal its contents */
   lock_all_threads();
+
+  block_collector(L, pt);
 
   if (TEST_INHERIT_THREAD_DELAY_MS > 0) {
     /* TR-1945: Both global trace and thread delref will grab
@@ -1675,9 +1676,9 @@ void luaC_inherit_thread(lua_State *L, lua_State *th)
     make_grey(L, steal);
   }
   TAILQ_REMOVE(&G(L)->all_heaps, th->heap, heaps);
-  unlock_all_threads();
-
   unblock_collector(L, pt);
+
+  unlock_all_threads();
 
   free(th->heap);
   th->heap = NULL;

--- a/src/lgc.c
+++ b/src/lgc.c
@@ -1626,8 +1626,11 @@ void luaC_inherit_thread(lua_State *L, lua_State *th)
   GCheader *steal, *tmp;
   thr_State *pt;
 
+  lua_lock(th);
+
   if (th->heap == NULL) {
     // already done
+    lua_unlock(th);
     return;
   }
 
@@ -1682,6 +1685,8 @@ void luaC_inherit_thread(lua_State *L, lua_State *th)
 
   free(th->heap);
   th->heap = NULL;
+
+  lua_unlock(th);
 
   ck_pr_inc_32(&G(L)->need_global_trace);
 }

--- a/src/lgc.c
+++ b/src/lgc.c
@@ -1624,11 +1624,15 @@ void luaC_inherit_thread(lua_State *L, lua_State *th)
 {
   int i;
   GCheader *steal, *tmp;
+  thr_State *pt;
 
   if (th->heap == NULL) {
     // already done
     return;
   }
+
+  pt = luaC_get_per_thread(L);
+  block_collector(L, pt);
 
   /* when a thread is reclaimed, the executing thread
    * needs to steal its contents */
@@ -1672,6 +1676,8 @@ void luaC_inherit_thread(lua_State *L, lua_State *th)
   }
   TAILQ_REMOVE(&G(L)->all_heaps, th->heap, heaps);
   unlock_all_threads();
+
+  unblock_collector(L, pt);
 
   free(th->heap);
   th->heap = NULL;


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Touches low-level coroutine lifecycle and concurrent GC/heap transfer logic; incorrect refcounting or lock ordering could cause leaks, deadlocks, or crashes under concurrency.
> 
> **Overview**
> Prevents garbage-collection races around thread suspension and reclaimed-thread heap transfer.
> 
> `lua_suspend` now increments the coroutine GC refcount and `lua_resume` decrements it when resuming from `LUA_SUSPEND`, pinning suspended coroutines until they are resumed.
> 
> `luaC_inherit_thread` now takes the target thread lock and blocks the collector while moving objects/heaps, ensuring global trace cannot run concurrently with heap inheritance and avoiding lock contention/corruption during transfer.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 13ee876e8d4697965dca2ddc8d6f261bb3240a4d. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->