### PR TITLE
TASK-218202 print lua upvalues

### DIFF
--- a/src/gimli.c
+++ b/src/gimli.c
@@ -455,7 +455,7 @@ static gimli_iter_status_t print_lua_State(gimli_proc_t proc,
           }
 
           /* read the upvalue name from p.upvalues[n] if available */
-          if (n < p.sizeupvalues &&
+          if (p.upvalues && n < p.sizeupvalues &&
               gimli_read_mem(proc, (gimli_addr_t)(p.upvalues + n),
                 &nameptr, sizeof(nameptr)) == sizeof(nameptr) && nameptr) {
             uvname = gimli_read_string(proc,


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Changes crash-dump output and increases memory reads while walking Lua closures, which could impact dump reliability or performance in edge cases. Default verbosity behavior also changes via `GIMLI_LUA_VERBOSE` semantics.
> 
> **Overview**
> Lua stack traces emitted by `print_lua_State` now include *upvalues* in addition to locals, for both C closures (iterating `CClosure.upvalue`) and Lua closures (walking `LClosure.upvals`, optionally naming them from `Proto.upvalues`).
> 
> The default behavior is flipped to dump the full `lua_State` expansion unless `GIMLI_LUA_VERBOSE=0` is set, and the env var handling is updated to treat any set value as an explicit on/off toggle.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit eab94b12f47284fd9b4973a8804384cadd1bc4f9. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->