### PR TITLE
#15 fix race condition with xref

### DIFF
--- a/src/lgc.c
+++ b/src/lgc.c
@@ -211,6 +211,16 @@ static INLINE int is_unknown_xref_val(lua_State *L, uint32_t val)
   return (val & 2) == 0;
 }
 
+static INLINE int was_prev_epoch_xref(lua_State *L, uint32_t val)
+{
+  uint32_t cur_isxref = ck_pr_load_32(&G(L)->isxref);
+
+  if ((cur_isxref & 3) == 1) {
+    return val == 3;
+  }
+  return val == 1;
+}
+
 static INLINE int is_unknown_xref(lua_State *L, GCheader *o) {
   uint32_t val = ck_pr_load_32(&o->xref);
 
@@ -230,14 +240,14 @@ static INLINE void set_xref(lua_State *L, GCheader *lval, GCheader *rval,
   } else if (force) {
     uint32_t old_val = ck_pr_load_32(&rval->xref);
 
-    if (is_unknown_xref_val(L, old_val)) {
+    if (is_unknown_xref_val(L, old_val) && !was_prev_epoch_xref(L, old_val)) {
       /* Here's the issue: There may be another thread marking this as an xref,
        * and if we mark it as _not_ an xref at the same time, we're gonna have
        * a bad time.  So, we:
        *
        * 1. Load the value and save it locally.
        * 2. Check if it's unknown.
-       * 3. If it's unknown, we run atomic CAS to compare it against the old
+       * 3. If it's unknown and not xref previously, we run atomic CAS to compare it against the old
        *    value and make it 'not' xref.  If somebody else changed it (either to
        *    not an xref, or an xref), that's cool.
        */


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Touches concurrency-sensitive GC xref bookkeeping; a small logic change, but mistakes could lead to missed external references or leaks under parallel tracing.
> 
> **Overview**
> Tightens `set_xref()` so its forced CAS to `notxref` only happens when the object’s `xref` is *unknown* **and** was not already marked as an xref in the previous global-trace epoch.
> 
> This adds `was_prev_epoch_xref()` to detect prior-epoch xref values and prevents clobbering them, reducing a race where one thread could clear another thread’s xref mark across epoch flips.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit f2b518f4cc8d9d021a96af04b2031893a69ce3e7. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->