### PR TITLE
#17 fix line number overflow in gimli trace

### DIFF
--- a/src/gimli.c
+++ b/src/gimli.c
@@ -394,10 +394,16 @@ static gimli_iter_status_t print_lua_State(gimli_proc_t proc,
 
       if (p.source) {
         char *src = gimli_read_string(proc, (gimli_addr_t)(p.source + 1));
-        int line;
+        int line = 0;
 
-        gimli_read_mem(proc, (gimli_addr_t)(p.lineinfo + pc), &line, sizeof(line));
-        printf("%s:%d @ pc=%d\n", src + 1, line, pc);
+        if (p.lineinfo && pc >= 0 && pc < p.sizelineinfo) {
+          gimli_read_mem(proc, (gimli_addr_t)(p.lineinfo + pc), &line, sizeof(line));
+        }
+        if (line > 0) {
+          printf("%s:%d @ pc=%d\n", src + 1, line, pc);
+        } else {
+          printf("%s @ pc=%d\n", src + 1, pc);
+        }
         free(src);
       } else {
         printf("[VM]\n");
@@ -406,21 +412,28 @@ static gimli_iter_status_t print_lua_State(gimli_proc_t proc,
       /* print out locals */
       for (sn = 0, n = 0; n < p.sizelocvars; n++) {
         char *varname;
-        int startline, endline;
+        int startline = 0, endline = 0;
         TValue val;
 
         if (gimli_read_mem(proc, (gimli_addr_t)(p.locvars + n), &lv, sizeof(lv)) != sizeof(lv)) {
           break;
         }
         if (lv.startpc > pc) {
-          /* this local is not yet valid in this frame */
           continue;
         }
 
         varname = gimli_read_string(proc, (gimli_addr_t)(((TString*)lv.varname) + 1));
-        gimli_read_mem(proc, (gimli_addr_t)(p.lineinfo + lv.startpc), &startline, sizeof(startline));
-        gimli_read_mem(proc, (gimli_addr_t)(p.lineinfo + lv.endpc), &endline, sizeof(endline));
-        printf("    local %s [lines: %d - %d] ", varname, startline, endline);
+        if (p.lineinfo) {
+          if (lv.startpc >= 0 && lv.startpc < p.sizelineinfo)
+            gimli_read_mem(proc, (gimli_addr_t)(p.lineinfo + lv.startpc), &startline, sizeof(startline));
+          if (lv.endpc >= 0 && lv.endpc < p.sizelineinfo)
+            gimli_read_mem(proc, (gimli_addr_t)(p.lineinfo + lv.endpc), &endline, sizeof(endline));
+        }
+        if (startline > 0 || endline > 0) {
+          printf("    local %s [lines: %d - %d] ", varname, startline, endline);
+        } else {
+          printf("    local %s ", varname);
+        }
         free(varname);
 
         /* we can read it from the stack at offset sn from the ci.base */

--- a/src/gimli.c
+++ b/src/gimli.c
@@ -411,7 +411,10 @@ static gimli_iter_status_t print_lua_State(gimli_proc_t proc,
         printf("[VM]\n");
       }
 
-      /* print out locals -- locvars is sorted by startpc */
+      /* print out locals -- locvars is sorted by startpc;
+       * a local is active when startpc <= pc < endpc
+       * (see luaF_getlocalname). Only active locals occupy
+       * stack slots, so sn must only advance for those. */
       for (sn = 0, n = 0; n < p.sizelocvars; n++) {
         char *varname;
         int startline = 0, endline = 0;
@@ -422,6 +425,9 @@ static gimli_iter_status_t print_lua_State(gimli_proc_t proc,
         }
         if (lv.startpc > pc) {
           break;
+        }
+        if (pc >= lv.endpc) {
+          continue;
         }
 
         varname = gimli_read_string(proc, (gimli_addr_t)(((TString*)lv.varname) + 1));

--- a/src/gimli.c
+++ b/src/gimli.c
@@ -394,6 +394,7 @@ static gimli_iter_status_t print_lua_State(gimli_proc_t proc,
 
       if (p.source) {
         char *src = gimli_read_string(proc, (gimli_addr_t)(p.source + 1));
+        const char *srcname = src ? src + 1 : "?";
         int line = 0;
 
         if (p.lineinfo && pc >= 0 && pc < p.sizelineinfo) {
@@ -401,9 +402,9 @@ static gimli_iter_status_t print_lua_State(gimli_proc_t proc,
             line = 0;
         }
         if (line > 0) {
-          printf("%s:%d @ pc=%d\n", src + 1, line, pc);
+          printf("%s:%d @ pc=%d\n", srcname, line, pc);
         } else {
-          printf("%s @ pc=%d\n", src + 1, pc);
+          printf("%s @ pc=%d\n", srcname, pc);
         }
         free(src);
       } else {
@@ -435,9 +436,9 @@ static gimli_iter_status_t print_lua_State(gimli_proc_t proc,
             endline = 0;
         }
         if (startline > 0 && endline > 0) {
-          printf("    local %s [lines: %d - %d] ", varname, startline, endline);
+          printf("    local %s [lines: %d - %d] ", varname ? varname : "?", startline, endline);
         } else {
-          printf("    local %s ", varname);
+          printf("    local %s ", varname ? varname : "?");
         }
         free(varname);
 

--- a/src/gimli.c
+++ b/src/gimli.c
@@ -397,7 +397,8 @@ static gimli_iter_status_t print_lua_State(gimli_proc_t proc,
         int line = 0;
 
         if (p.lineinfo && pc >= 0 && pc < p.sizelineinfo) {
-          gimli_read_mem(proc, (gimli_addr_t)(p.lineinfo + pc), &line, sizeof(line));
+          if (gimli_read_mem(proc, (gimli_addr_t)(p.lineinfo + pc), &line, sizeof(line)) != sizeof(line))
+            line = 0;
         }
         if (line > 0) {
           printf("%s:%d @ pc=%d\n", src + 1, line, pc);
@@ -409,7 +410,7 @@ static gimli_iter_status_t print_lua_State(gimli_proc_t proc,
         printf("[VM]\n");
       }
 
-      /* print out locals */
+      /* print out locals -- locvars is sorted by startpc */
       for (sn = 0, n = 0; n < p.sizelocvars; n++) {
         char *varname;
         int startline = 0, endline = 0;
@@ -419,17 +420,21 @@ static gimli_iter_status_t print_lua_State(gimli_proc_t proc,
           break;
         }
         if (lv.startpc > pc) {
-          continue;
+          break;
         }
 
         varname = gimli_read_string(proc, (gimli_addr_t)(((TString*)lv.varname) + 1));
         if (p.lineinfo) {
-          if (lv.startpc >= 0 && lv.startpc < p.sizelineinfo)
-            gimli_read_mem(proc, (gimli_addr_t)(p.lineinfo + lv.startpc), &startline, sizeof(startline));
-          if (lv.endpc >= 0 && lv.endpc < p.sizelineinfo)
-            gimli_read_mem(proc, (gimli_addr_t)(p.lineinfo + lv.endpc), &endline, sizeof(endline));
+          if (lv.startpc >= 0 && lv.startpc < p.sizelineinfo &&
+              gimli_read_mem(proc, (gimli_addr_t)(p.lineinfo + lv.startpc), &startline, sizeof(startline)) != sizeof(startline))
+            startline = 0;
+          /* endpc is exclusive (first pc where the local is dead),
+           * so the last valid line is at endpc-1 */
+          if (lv.endpc > 0 && lv.endpc - 1 < p.sizelineinfo &&
+              gimli_read_mem(proc, (gimli_addr_t)(p.lineinfo + lv.endpc - 1), &endline, sizeof(endline)) != sizeof(endline))
+            endline = 0;
         }
-        if (startline > 0 || endline > 0) {
+        if (startline > 0 && endline > 0) {
           printf("    local %s [lines: %d - %d] ", varname, startline, endline);
         } else {
           printf("    local %s ", varname);


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Low risk diagnostic-only change that adds bounds checks and safer printing to avoid invalid `lineinfo` reads and incorrect local variable slot mapping in Lua stack traces.
> 
> **Overview**
> Improves Lua stack-trace rendering in `src/gimli.c` by **hardening source/line lookups**: it now bounds-checks `pc`/`lineinfo` accesses, tolerates failed reads, and prints frames without a line number when unavailable.
> 
> Fixes **local variable reporting** by only advancing stack-slot offsets for locals that are actually active at the current `pc`, and by computing local end-line using `endpc-1` (since `endpc` is exclusive), with graceful fallback when line metadata is missing.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 4f79f2a0388323460fb0c3bd815dce82a34a0d1d. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->