### PR TITLE
#21 call asan on setjmp

### DIFF
--- a/src/luaconf.h
+++ b/src/luaconf.h
@@ -692,7 +692,6 @@ static inline void lua_number2str(char *buf, LUA_NUMBER n)
 ** compiling as C++ code, with _longjmp/_setjmp when asked to use them,
 ** and with longjmp/setjmp otherwise.
 */
-
 #if defined(__cplusplus)
 /* C++ exceptions */
 #define LUAI_THROW(L,c)	throw(c)

--- a/src/luaconf.h
+++ b/src/luaconf.h
@@ -692,6 +692,9 @@ static inline void lua_number2str(char *buf, LUA_NUMBER n)
 ** compiling as C++ code, with _longjmp/_setjmp when asked to use them,
 ** and with longjmp/setjmp otherwise.
 */
+
+void __asan_handle_no_return(void);
+
 #if defined(__cplusplus)
 /* C++ exceptions */
 #define LUAI_THROW(L,c)	throw(c)
@@ -701,13 +704,13 @@ static inline void lua_number2str(char *buf, LUA_NUMBER n)
 
 #elif defined(LUA_USE_ULONGJMP)
 /* in Unix, try _longjmp/_setjmp (more efficient) */
-#define LUAI_THROW(L,c)	lua_do_longjmp((c)->b, 1)
+#define LUAI_THROW(L,c)	do { __asan_handle_no_return(); lua_do_longjmp((c)->b, 1); } while(0)
 #define LUAI_TRY(L,c,a)	if (lua_do_setjmp((c)->b) == 0) { a }
 #define luai_jmpbuf	jmp_buf
 
 #else
 /* default handling with long jumps */
-#define LUAI_THROW(L,c)	lua_do_longjmp((c)->b, 1)
+#define LUAI_THROW(L,c)	do { __asan_handle_no_return(); lua_do_longjmp((c)->b, 1); } while(0)
 #define LUAI_TRY(L,c,a)	if (lua_do_setjmp((c)->b) == 0) { a }
 #define luai_jmpbuf	jmp_buf
 

--- a/src/luaconf.h
+++ b/src/luaconf.h
@@ -693,8 +693,6 @@ static inline void lua_number2str(char *buf, LUA_NUMBER n)
 ** and with longjmp/setjmp otherwise.
 */
 
-void __asan_handle_no_return(void);
-
 #if defined(__cplusplus)
 /* C++ exceptions */
 #define LUAI_THROW(L,c)	throw(c)
@@ -704,13 +702,13 @@ void __asan_handle_no_return(void);
 
 #elif defined(LUA_USE_ULONGJMP)
 /* in Unix, try _longjmp/_setjmp (more efficient) */
-#define LUAI_THROW(L,c)	do { __asan_handle_no_return(); lua_do_longjmp((c)->b, 1); } while(0)
+#define LUAI_THROW(L,c)	lua_do_longjmp((c)->b, 1)
 #define LUAI_TRY(L,c,a)	if (lua_do_setjmp((c)->b) == 0) { a }
 #define luai_jmpbuf	jmp_buf
 
 #else
 /* default handling with long jumps */
-#define LUAI_THROW(L,c)	do { __asan_handle_no_return(); lua_do_longjmp((c)->b, 1); } while(0)
+#define LUAI_THROW(L,c)	lua_do_longjmp((c)->b, 1)
 #define LUAI_TRY(L,c,a)	if (lua_do_setjmp((c)->b) == 0) { a }
 #define luai_jmpbuf	jmp_buf
 

--- a/src/thrlua.h
+++ b/src/thrlua.h
@@ -223,7 +223,7 @@ struct lua_longjmp {
 ** intercept them and properly unpoison skipped stack frames.
 ** The custom asm versions bypass ASAN and cause false positives.
 */
-#if defined(__SANITIZE_ADDRESS__) || (defined(__has_feature) && __has_feature(address_sanitizer))
+#if defined(__SANITIZE_ADDRESS__)
 # define lua_do_setjmp  setjmp
 # define lua_do_longjmp longjmp
 #elif LUA_ARCH_X86_64

--- a/src/thrlua.h
+++ b/src/thrlua.h
@@ -218,7 +218,15 @@ struct lua_longjmp {
 # define LUA_ASMNAME(x) _##x
 #endif
 
-#if LUA_ARCH_X86_64
+/*
+** Under AddressSanitizer, use system setjmp/longjmp so ASAN can
+** intercept them and properly unpoison skipped stack frames.
+** The custom asm versions bypass ASAN and cause false positives.
+*/
+#if defined(__SANITIZE_ADDRESS__) || (defined(__has_feature) && __has_feature(address_sanitizer))
+# define lua_do_setjmp  setjmp
+# define lua_do_longjmp longjmp
+#elif LUA_ARCH_X86_64
 # define lua_do_setjmp  LUA_ASMNAME(lua_setjmp_amd64)
 # define lua_do_longjmp LUA_ASMNAME(lua_longjmp_amd64)
 #elif LUA_ARCH_I386


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Low risk: behavior changes only under `__SANITIZE_ADDRESS__`, but it touches the core longjmp-based error/exception path during ASAN-instrumented builds.
> 
> **Overview**
> When compiling with AddressSanitizer (`__SANITIZE_ADDRESS__`), `thrlua.h` now maps `lua_do_setjmp`/`lua_do_longjmp` to the system `setjmp`/`longjmp` instead of the custom assembly implementations.
> 
> This lets ASAN intercept the jump functions and correctly unpoison skipped stack frames, reducing ASAN false positives during Lua error handling.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 18b15070f1e5369cc6b6ed8bdbec49756f28e5e4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->