### PR TITLE
#23 fix buffer size accounting bug

### DIFF
--- a/src/lstate.c
+++ b/src/lstate.c
@@ -209,7 +209,7 @@ static void close_state (lua_State *L) {
   luaF_close(L, L->stack);  /* close all upvalues for this thread */
   freestack(L);
   luaZ_freebuffer(L, &L->buff);
-  luaM_freemem(L, LUA_MEM_THREAD, L, sizeof(*L) + g->extraspace);
+  luaM_freemem(L, LUA_MEM_THREAD, L, sizeof(*L));
 }
 
 lua_State *luaE_newthread (lua_State *L) {

--- a/src/lstate.c
+++ b/src/lstate.c
@@ -209,7 +209,7 @@ static void close_state (lua_State *L) {
   luaF_close(L, L->stack);  /* close all upvalues for this thread */
   freestack(L);
   luaZ_freebuffer(L, &L->buff);
-  luaM_freemem(L, LUA_MEM_THREAD, L, sizeof(*L));
+  luaM_freemem(L, LUA_MEM_THREAD, L, sizeof(*L) + g->extraspace);
 }
 
 lua_State *luaE_newthread (lua_State *L) {
@@ -260,7 +260,7 @@ void luaE_freethread (lua_State *L, lua_State *L1) {
   pthread_mutex_destroy(&L1->lock);
   luaZ_freebuffer(L1, &L1->buff);
   if (L1 != G(L1)->mainthread) {
-    luaM_freemem(L, LUA_MEM_THREAD, L1, sizeof(lua_State));
+    luaM_freemem(L, LUA_MEM_THREAD, L1, sizeof(lua_State) + G(L1)->extraspace);
   }
 }
 


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Touches low-level `lua_State` memory deallocation; incorrect sizing could cause leaks or allocator corruption if the new size is wrong, but the change is small and aligns with existing allocation paths.
> 
> **Overview**
> Fixes a buffer/accounting bug when freeing non-main Lua threads by updating `luaE_freethread` to release `sizeof(lua_State) + G(L1)->extraspace` instead of just `sizeof(lua_State)`.
> 
> This makes thread deallocation consistent with the extra space included during thread/global-state allocation, preventing under-freeing of memory when `extraspace` is configured.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fd63fe2d0e1e86e0863063d68fe8bc9ab6e119b2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->