### PR TITLE
#25 lock before resizing table

### DIFF
--- a/src/ltable.c
+++ b/src/ltable.c
@@ -298,18 +298,10 @@ static void resize (lua_State *L, Table *t, int nasize, int nhsize) {
   int oldhsize = t->lsizenode;
   Node *nold = t->node;  /* save old hash ... */
 
+  luaH_wrlock(L, t);
   luaC_blockcollector(L);
   if (nasize > oldasize)  /* array part must grow? */
     setarrayvector(L, t, nasize);
-  /* create new hash part with appropriate size */
-  /* XXX There is a race in here.  t->node is repalced with a new empty array
-   * which happens safely.  However, the old array is no longer referenced
-   * in the Table structure.  In practical terms this means that entries
-   * that are cross-referenced may have that status cleared, and then a race
-   * may exist between the owning thread's garbage collector and that of
-   * the referencing thread.  This problem has existed forever, however, so
-   * it may not happen in real life.  But, it's something to keep an eye on
-   * XXX */
   setnodevector(L, t, nhsize);  
   if (nasize < oldasize) {  /* array part must shrink? */
     t->sizearray = nasize;
@@ -332,6 +324,7 @@ static void resize (lua_State *L, Table *t, int nasize, int nhsize) {
     luaM_freearray(L, LUA_MEM_TABLE_NODES, nold, twoto(oldhsize), Node);
   }
   luaC_unblockcollector(L);
+  luaH_wrunlock(L, t);
 }
 
 

--- a/src/lvm.c
+++ b/src/lvm.c
@@ -850,10 +850,10 @@ void luaV_execute (lua_State *L, int nexeccalls) {
         runtime_check(L, ttistable(ra));
         h = hvalue(ra);
         last = ((c-1)*LFIELDS_PER_FLUSH) + n;
+        if (last > h->sizearray)  /* needs more space? */
+          luaH_resizearray(L, h, last);  /* pre-alloc it at once */
         luaH_wrlock(L, h);
         LUAI_TRY_BLOCK(L) {
-          if (last > h->sizearray)  /* needs more space? */
-            luaH_resizearray(L, h, last);  /* pre-alloc it at once */
           for (; n > 0; n--) {
             TValue *val = ra+n;
             TValue *src = luaH_setnum(L, h, last--);


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Adjusts table resizing and list-set preallocation to change lock acquisition order in core VM paths; mistakes here could introduce deadlocks or subtle races in concurrent table/GC usage.
> 
> **Overview**
> **Table resizing is now explicitly synchronized.** `ltable.c` wraps the internal `resize()` logic with `luaH_wrlock`/`luaH_wrunlock`, and removes an outdated comment about a potential race during `t->node` replacement.
> 
> **VM list construction lock ordering is adjusted.** In `OP_SETLIST` (`lvm.c`), the array growth preallocation via `luaH_resizearray()` is moved to occur *before* acquiring the table write lock, avoiding resize attempts while already holding the lock.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f2ade240b3c1ba376a2f858272fe99c2a2fa5c64. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->