### PR TITLE
#27 capture gcheader in trace

### DIFF
--- a/src/gimli.c
+++ b/src/gimli.c
@@ -584,14 +584,23 @@ static gimli_iter_status_t print_GCheader(gimli_proc_t proc,
     int depth, void *arg)
 {
   GCheader h;
+  const char *datatype = gimli_type_declname(t);
+
+  if (!varname) varname = "";
+
+  if (varaddr == 0) {
+    printf("    %s %s = nil\n", datatype, varname);
+    return GIMLI_ANA_SUPPRESS;
+  }
 
   if (gimli_read_mem(proc, varaddr, &h, sizeof(h)) != sizeof(h)) {
-    return GIMLI_ITER_CONT;
+    printf("    %s %s = %p <unable to read>\n", datatype, varname,
+        (void*)varaddr);
+    return GIMLI_ANA_SUPPRESS;
   }
 
   printf("    %s %s = %p {tt=%s(%d), xref=%u, marked=%u, ref=%u, owner=%p}\n",
-      gimli_type_declname(t),
-      varname ? varname : "",
+      datatype, varname,
       (void*)varaddr,
       lua_typename_for_tt(h.tt), h.tt,
       h.xref, (unsigned)h.marked, h.ref,

--- a/src/gimli.c
+++ b/src/gimli.c
@@ -561,18 +561,19 @@ static gimli_iter_status_t print_lua_State(gimli_proc_t proc,
 static const char *lua_typename_for_tt(int tt)
 {
   switch (tt) {
-    case 0: return "nil";
-    case 1: return "bool";
-    case 2: return "lightuserdata";
-    case 3: return "number";
-    case 4: return "string";
-    case 5: return "table";
-    case 6: return "function";
-    case 7: return "userdata";
-    case 8: return "thread";
-    case 9: return "proto";
-    case 10: return "upval";
-    case 11: return "global";
+    case LUA_TNIL: return "nil";
+    case LUA_TBOOLEAN: return "bool";
+    case LUA_TLIGHTUSERDATA: return "lightuserdata";
+    case LUA_TNUMBER: return "number";
+    case LUA_TSTRING: return "string";
+    case LUA_TTABLE: return "table";
+    case LUA_TFUNCTION: return "function";
+    case LUA_TUSERDATA: return "userdata";
+    case LUA_TTHREAD: return "thread";
+    case LUA_TPROTO: return "proto";
+    case LUA_TUPVAL: return "upval";
+    case LUA_TDEADKEY: return "deadkey";
+    case LUA_TGLOBAL: return "global";
     default: return "INVALID";
   }
 }

--- a/src/gimli.c
+++ b/src/gimli.c
@@ -558,7 +558,49 @@ static gimli_iter_status_t print_lua_State(gimli_proc_t proc,
   return ret;
 }
 
+static const char *lua_typename_for_tt(int tt)
+{
+  switch (tt) {
+    case 0: return "nil";
+    case 1: return "bool";
+    case 2: return "lightuserdata";
+    case 3: return "number";
+    case 4: return "string";
+    case 5: return "table";
+    case 6: return "function";
+    case 7: return "userdata";
+    case 8: return "thread";
+    case 9: return "proto";
+    case 10: return "upval";
+    case 11: return "global";
+    default: return "INVALID";
+  }
+}
+
+static gimli_iter_status_t print_GCheader(gimli_proc_t proc,
+    gimli_stack_frame_t frame,
+    const char *varname, gimli_type_t t, gimli_addr_t varaddr,
+    int depth, void *arg)
+{
+  GCheader h;
+
+  if (gimli_read_mem(proc, varaddr, &h, sizeof(h)) != sizeof(h)) {
+    return GIMLI_ITER_CONT;
+  }
+
+  printf("    %s %s = %p {tt=%s(%d), xref=%u, marked=%u, ref=%u, owner=%p}\n",
+      gimli_type_declname(t),
+      varname ? varname : "",
+      (void*)varaddr,
+      lua_typename_for_tt(h.tt), h.tt,
+      h.xref, (unsigned)h.marked, h.ref,
+      (void*)h.owner);
+
+  return GIMLI_ANA_SUPPRESS;
+}
+
 static const char *lua_state_typenames[] = { "struct lua_State" };
+static const char *gcheader_typenames[] = { "struct GCheader" };
 
 int gimli_module_init(int api_version)
 {
@@ -591,6 +633,8 @@ int gimli_module_init(int api_version)
 
   gimli_module_register_var_printer_for_types(lua_state_typenames, 1,
       print_lua_State, NULL);
+  gimli_module_register_var_printer_for_types(gcheader_typenames, 1,
+      print_GCheader, NULL);
 
   return 1;
 }

--- a/src/lgc.c
+++ b/src/lgc.c
@@ -15,6 +15,12 @@
 # define INLINE inline
 #endif
 
+#ifdef __GNUC__
+#define KEEP_FOR_DEBUG(var) __asm__ __volatile__("" :: "r"(var))
+#else
+#define KEEP_FOR_DEBUG(var) ((void)(var))
+#endif
+
 /* Perform global traces in parallel, as opposed to having just one thread
  * do it. Set to 0 to disable. */
 static int USE_TRACE_THREADS = 1;
@@ -672,6 +678,7 @@ static INLINE int is_world_stopped(lua_State *L)
 static void traverse_object(lua_State *L, GCheader *o, objfunc_t objfunc)
 {
   int i;
+  KEEP_FOR_DEBUG(o);
 
   switch (o->tt) {
     case LUA_TSTRING:
@@ -913,6 +920,8 @@ static void traverse_object(lua_State *L, GCheader *o, objfunc_t objfunc)
 
 static void grey_object(lua_State *L, GCheader *lval, GCheader *rval)
 {
+  KEEP_FOR_DEBUG(lval);
+  KEEP_FOR_DEBUG(rval);
   mark_object(L, rval);
 }
 
@@ -2105,7 +2114,10 @@ lua_name_thread(char *thread_name)
 
 static void global_trace_obj(lua_State *L, GCheader *lval, GCheader *rval)
 {
-  int recurse = is_unknown_xref(L, rval);
+  int recurse;
+  KEEP_FOR_DEBUG(lval);
+  KEEP_FOR_DEBUG(rval);
+  recurse = is_unknown_xref(L, rval);
 
   set_xref(L, lval, rval, 1);
 


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Touches garbage-collector tracing code and adds new debug-oriented behavior, which could affect GC correctness or introduce subtle performance/tooling impacts if misused. Functional changes are limited and mostly aimed at improving observability.
> 
> **Overview**
> Improves debugging/observability of Lua GC objects during crash/trace analysis.
> 
> Adds a new gimli var printer for `struct GCheader` that safely reads the header from the target process and prints key fields (`tt`, `xref`, `marked`, `ref`, `owner`) with a Lua type name mapping.
> 
> Updates GC tracing helpers in `lgc.c` with a `KEEP_FOR_DEBUG` macro to force key `GCheader*` arguments to remain visible to debuggers/diagnostics (including in `traverse_object`, `grey_object`, and `global_trace_obj`), plus a small refactor to avoid initializing `recurse` inline.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d793baeb89f920978f1d36067957f8c88af2b338. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->