### PR TITLE
#29 lua get refcount api

### DIFF
--- a/src/lapi.c
+++ b/src/lapi.c
@@ -176,6 +176,11 @@ LUA_API void lua_addrefthread(lua_State *L)
   ck_pr_inc_32(&L->gch.ref);
 }
 
+LUA_API unsigned int lua_threadrefcount(lua_State *L)
+{
+  return ck_pr_load_32(&L->gch.ref);
+}
+
 LUA_API lua_State *lua_newthreadref (lua_State *L)
 {
   lua_State *L1 = NULL;

--- a/src/lua.h
+++ b/src/lua.h
@@ -246,6 +246,9 @@ LUA_API void lua_pushobjref(lua_State *L, void *ref);
  * without deadlock. */
 LUA_API void      (lua_delrefthread)(lua_State *L, lua_State *inheritor);
 
+/* Diagnostic: snapshot of the thread's reference count */
+LUA_API unsigned int (lua_threadrefcount)(lua_State *L);
+
 LUA_API lua_CFunction (lua_atpanic) (lua_State *L, lua_CFunction panicf);
 
 


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Low risk: adds a read-only diagnostic API that atomically reads `lua_State` refcounts without changing existing refcounting behavior, but it does extend the public C API/ABI surface.
> 
> **Overview**
> Adds a new public C API, `lua_threadrefcount(lua_State *L)`, to let callers retrieve a snapshot of a thread’s current reference count.
> 
> Implements the function in `lapi.c` using an atomic load of `L->gch.ref` and exposes the declaration in `lua.h` for external consumers.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a6c49957e20d3b2bc438a80391e81d937324d67c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->