### PR TITLE
#31 fix UAF: normalize inherited object color before make_grey

### DIFF
--- a/src/lgc.c
+++ b/src/lgc.c
@@ -1677,6 +1677,13 @@ void luaC_inherit_thread(lua_State *L, lua_State *th)
     TAILQ_REMOVE(&th->heap->objects, steal, allocd);
     TAILQ_INSERT_HEAD(&L->heap->objects, steal, allocd);
 
+    /* Normalize color to the inheritor's cycle before make_grey: a stale
+     * GREYBIT from the dead thread makes make_grey a no-op, leaving the
+     * object grey but on no grey stack — invisible to propagate and
+     * check_references, so reclaim frees it while still referenced.
+     * Keep FINALBIT etc.; only the color bits are per-cycle. */
+    steal->marked = (steal->marked & ~(GREYBIT|BLACKBIT)) | !L->black;
+
     make_grey(L, steal);
   }
   TAILQ_REMOVE(&G(L)->all_heaps, th->heap, heaps);


### PR DESCRIPTION
luaC_inherit_thread steals a dead thread's objects into the inheritor heap and calls make_grey() on each. make_grey() is a no-op when GREYBIT is already set, which is true for any object the dead thread allocated since its last propagate (routine with allocating __gc finalizers and dead coroutines). Such an object ends up grey but on no grey stack: invisible to the propagate loop and to check_references, so a later reclaim frees it while it is still referenced (its guards in reclaim_white are lua_assert_obj, compiled out in release). The next global trace then walks freed, reused memory -> "marking for tt not implemented" abort on lua-gtrace, or a wild-pointer SIGSEGV on t-gc (observed on production).

Clear the color bits and set the object white in the inheritor's cycle before make_grey, so make_grey actually pushes it onto the grey stack and it is traced (and thus kept-or-reclaimed correctly) this cycle. FINALBIT and other non-color bits are preserved.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Targets a production MTA GC UAF (premature free of still-referenced objects after thread inheritance); the change is small but sits on critical concurrent collector correctness.
> 
> **Overview**
> Fixes a **use-after-free** when a dead coroutine’s heap is merged into the inheritor via `luaC_inherit_thread`.
> 
> Inherited objects could still carry **`GREYBIT` from the dead thread’s last GC cycle**. `make_grey()` then returns immediately without pushing onto the inheritor’s grey stack, so those objects are neither propagated nor rescued by `check_references`, and **`reclaim_white` can free them while still referenced**.
> 
> Before calling `make_grey`, the change **clears only the color bits** (`GREYBIT`/`BLACKBIT`), sets the object to the inheritor’s current white/black cycle, and **leaves flags like `FINALBIT` unchanged**, so inherited objects are actually greyed and traced in the inheritor’s collection.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit cf6e6de36f1ff146c889f8a889830b3bf41bf232. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->